### PR TITLE
Display fixed toolbars in front of "default" toolbars

### DIFF
--- a/src/stylus/components/_toolbar.styl
+++ b/src/stylus/components/_toolbar.styl
@@ -3,7 +3,6 @@
   transition: .3s $transition.swing
   width: 100%
   will-change: padding-left
-  z-index: 2
   elevation(4)
     
   .input-group--solo
@@ -93,6 +92,7 @@
     
   &--fixed
     position: fixed
+    z-index: 2
 
   &--fixed, &--absolute
     top: 0


### PR DESCRIPTION
"Default" toolbars are displayed in front of fixed toolbars if the toolbar is scrolled.
This PR fixes this and sets the `z-index` only for fixed toolbars.

As I had no time to test this, this PR is more like a issue with a proposed solution.